### PR TITLE
fix display of top-aligned buttons in ie11

### DIFF
--- a/src/scss/react-dual-listbox.scss
+++ b/src/scss/react-dual-listbox.scss
@@ -156,7 +156,7 @@ $rdl-line-height: 1.428571429 !default;
   }
 
   .rdl-move {
-    flex: 0 0 50%;
+    flex: 0 1 50%;
 
     &:first-child {
       margin-bottom: 0;


### PR DESCRIPTION
This change should fix the issue with top-aligned buttons not displaying correctly in ie11.  Changing this flexbox setting didn't seem to have any effects on other browsers - but they were all displaying fine.

I'm far from an expert with CSS so I'm not certain that this is the best fix, but it is a fix.