### PR TITLE
support styled-components and fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jsdom": "^15.0.0",
     "mocha": "^6.0.0",
     "natives": "^1.1.6",
+    "node-sass": "^4.12.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-test-renderer": "^16.3.0",

--- a/src/js/DualListBox.js
+++ b/src/js/DualListBox.js
@@ -54,6 +54,7 @@ class DualListBox extends React.Component {
         available: valueShape,
         availableRef: PropTypes.func,
         canFilter: PropTypes.bool,
+        className: PropTypes.string,
         disabled: PropTypes.bool,
         filter: PropTypes.shape({
             available: PropTypes.string.isRequired,
@@ -82,6 +83,7 @@ class DualListBox extends React.Component {
         available: undefined,
         availableRef: null,
         canFilter: false,
+        className: undefined,
         disabled: false,
         filter: null,
         filterPlaceholder: 'Search...',
@@ -710,6 +712,7 @@ class DualListBox extends React.Component {
             alignActions,
             availableRef,
             canFilter,
+            className,
             disabled,
             icons,
             lang,
@@ -747,7 +750,7 @@ class DualListBox extends React.Component {
                 {makeAction('left', true)}
             </div>
         );
-        const className = classNames({
+        const classes = classNames(className, {
             'react-dual-listbox': true,
             'rdl-has-filter': canFilter,
             'rdl-has-header': showHeaderLabels,
@@ -756,7 +759,7 @@ class DualListBox extends React.Component {
         const value = this.getFlatOptions(selected).join(',');
 
         return (
-            <div className={className} id={id}>
+            <div className={classes} id={id}>
                 {this.renderListBox('available', availableOptions, availableRef, actionsRight)}
                 {alignActions === ALIGNMENTS.MIDDLE ? (
                     <div className="rdl-actions">

--- a/src/less/react-dual-listbox.less
+++ b/src/less/react-dual-listbox.less
@@ -79,9 +79,9 @@
 
 .rdl-actions {
   display: flex;
+  margin: 0 10px;
   flex: 0 0 auto;
   flex-direction: column;
-  margin: 0 10px;
 
   .rdl-has-header & {
     padding-top: 31px;
@@ -163,8 +163,8 @@
 
   .rdl-actions-left,
   .rdl-actions-right {
-    flex-direction: row;
     margin: 0;
+    flex-direction: row;
   }
 
   .rdl-move {

--- a/src/scss/react-dual-listbox.scss
+++ b/src/scss/react-dual-listbox.scss
@@ -79,9 +79,9 @@ $rdl-line-height: 1.42857 !default;
 
 .rdl-actions {
   display: flex;
+  margin: 0 10px;
   flex: 0 0 auto;
   flex-direction: column;
-  margin: 0 10px;
 
   .rdl-has-header & {
     padding-top: 31px;
@@ -163,8 +163,8 @@ $rdl-line-height: 1.42857 !default;
 
   .rdl-actions-left,
   .rdl-actions-right {
-    flex-direction: row;
     margin: 0;
+    flex-direction: row;
   }
 
   .rdl-move {


### PR DESCRIPTION
I'm trying to use this package in a project that uses `styled-components`, but wrapping the `DualListBox` component requires the ability to pass `className`.

Changes include:
1. Add `className` prop type
2. Pass `className` as first class in list of classes for root element
3. Fix minor build issue related to missing `node-sass` dependency issue

Confirmed that tests are passing and the solution works in my own project with `styled-components`.
