### PR TITLE
#124: Auto scrolling behavior in Firefox fixed.

### DIFF
--- a/src/js/DualListBox.js
+++ b/src/js/DualListBox.js
@@ -623,7 +623,9 @@ class DualListBox extends React.Component {
         const { id } = this.state;
 
         return options.map((option, index) => {
-            const key = `${option.value}-${option.label}-${index}`;
+            const key = !allowDuplicates 
+                        ? `${option.value}-${option.label}` 
+                        : `${option.value}-${option.label}-${index}`;
 
             if (option.options !== undefined) {
                 return (


### PR DESCRIPTION
Hey there @jakezatecky 

**Issue:**
In renderOptions method, each option takes a key created with value, label, and the index.
Some of these keys change whenever data changes, this cause the box to scroll to the top in Firefox.

**Solution:**
**With this fix**, if allowDuplicates false, the key takes the same phrase every render.

I think **another solution** could be this:
The options can be populated with a unique key before the creation of the availableOptions and the selectedOptions in the render. Thus, the key doesn't change when the selected item is moved between boxes.

**Screenshot:**
![Peek 2020-11-29 19-30](https://user-images.githubusercontent.com/26231317/100547745-6c0aa280-3279-11eb-9c59-4e3848c48491.gif)
